### PR TITLE
Added option to specify backup and maintenance window on RDS and Aurora

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 | allow\_security\_group\_ids | List of Security Group IDs to allow connection to this DB | `list(string)` | `[]` | no |
 | apply\_immediately | Apply changes immediately or wait for the maintainance window | `bool` | `true` | no |
 | backup | Enables automatic backup with AWS Backup | `bool` | n/a | yes |
+| backup\_window | (RDS Only) The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"03:00-03:30"` | no |
 | cluster\_parameters | A list of Cluster parameters (map) to apply | `list(map(string))` | `[]` | no |
 | count\_aurora\_instances | Number of Aurora Instances | `number` | `"1"` | no |
 | create\_cluster\_parameter\_group | Whether to create a cluster parameter group | `bool` | `false` | no |
@@ -49,6 +50,7 @@
 | instance\_class | n/a | `string` | n/a | yes |
 | kms\_key\_arn | KMS Key ARN to use a CMK instead of default shared key, when storage\_encrypted is true | `string` | `""` | no |
 | license\_model | License model information for this DB instance (Optional, but required for some DB engines, i.e. Oracle SE1 and SQL Server) | `string` | `null` | no |
+| maintenance\_window | (RDS Only) The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | `"Sun:04:00-Sun:05:00"` | no |
 | major\_engine\_version | Specifies the major version of the engine that this option group should be associated with | `string` | `""` | no |
 | max\_allocated\_storage | Argument higher than the allocated\_storage to enable Storage Autoscaling, size in GB. 0 to disable Storage Autoscaling | `number` | `0` | no |
 | monitoring\_interval | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance | `number` | `0` | no |
@@ -63,7 +65,8 @@
 | parameter\_group\_name | Name of the DB parameter group to associate or create | `string` | `null` | no |
 | performance\_insights\_enabled | Enable performance insights on instance | `bool` | `false` | no |
 | port | Port number for this DB (usually 3306 for MySQL and 5432 for Postgres) | `number` | n/a | yes |
-| preferred\_backup\_window | Preferred Backup Window | `string` | `"07:00-09:00"` | no |
+| preferred\_backup\_window | (Aurora Only) The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"07:00-09:00"` | no |
+| preferred\_maintenance\_window | (Aurora Only) The weekly time range during which system maintenance can occur, in (UTC) e.g., wed:04:00-wed:04:30 | `string` | `"Sun:04:00-Sun:05:00"` | no |
 | publicly\_accessible | (Optional) Bool to control if instance is publicly accessible | `bool` | `false` | no |
 | retention | Snapshot retention period in days | `number` | n/a | yes |
 | secret\_method | Use ssm for SSM parameters store which is the default option, or secretsmanager for AWS Secrets Manager | `string` | `"ssm"` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -138,7 +138,7 @@ variable "db_subnet_group_subnet_ids" {
 }
 
 variable "preferred_backup_window" {
-  description = "Preferred Backup Window"
+  description = "(Aurora Only) The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window"
   type        = string
   default     = "07:00-09:00"
 }
@@ -295,4 +295,22 @@ variable "monitoring_interval" {
   type        = number
   description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance"
   default     = 0
+}
+
+variable "maintenance_window" {
+  type        = string
+  description = "(RDS Only) The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'"
+  default     = "Sun:04:00-Sun:05:00"
+}
+
+variable "backup_window" {
+  description = "(RDS Only) The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window"
+  type        = string
+  default     = "03:00-03:30"
+}
+
+variable "preferred_maintenance_window" {
+  type        = string
+  description = "(Aurora Only) The weekly time range during which system maintenance can occur, in (UTC) e.g., wed:04:00-wed:04:30"
+  default     = "Sun:04:00-Sun:05:00"
 }

--- a/aurora.tf
+++ b/aurora.tf
@@ -8,6 +8,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   master_password                     = random_string.rds_db_password.result
   backup_retention_period             = var.retention
   preferred_backup_window             = var.preferred_backup_window
+  preferred_maintenance_window        = var.preferred_maintenance_window
   snapshot_identifier                 = var.snapshot_identifier != "" ? var.snapshot_identifier : null
   db_subnet_group_name                = try(aws_db_subnet_group.rds_subnet_group[0].id, var.db_subnet_group_id)
   iam_database_authentication_enabled = var.iam_database_authentication_enabled

--- a/rds.tf
+++ b/rds.tf
@@ -33,6 +33,8 @@ resource "aws_db_instance" "rds_db" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   monitoring_interval             = var.monitoring_interval
   monitoring_role_arn             = var.monitoring_interval > 0 ? aws_iam_role.rds_monitoring[count.index].arn : ""
+  maintenance_window              = var.maintenance_window
+  backup_window                   = var.backup_window
 
   tags = {
     Backup = var.backup


### PR DESCRIPTION
Feature: Added option to specify backup and maintenance window on RDS (db_instance) and Aurora Cluster (aws_rds_cluster)
`maintenance_window` (RDS)
`backup_window` (RDS)
`preferred_maintenance_window` (Aurora Cluster)
`preferred_backup_window` (Aurora Cluster)

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...