### PR TITLE
fix for deprecated attribute warning

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -14,7 +14,7 @@ resource "aws_db_instance" "rds_db" {
   engine                          = var.engine
   engine_version                  = var.engine_version
   instance_class                  = var.instance_class
-  name                            = var.database_name
+  db_name                         = var.database_name
   backup_retention_period         = var.retention
   identifier                      = var.identifier == "" ? "${var.environment_name}-${var.name}" : var.identifier
   username                        = var.user

--- a/secrets-manager.tf
+++ b/secrets-manager.tf
@@ -11,7 +11,7 @@ locals {
     username        = var.db_type == "rds" ? aws_db_instance.rds_db[0].username : aws_rds_cluster.aurora_cluster[0].master_username
     password        = random_string.rds_db_password.result
     port            = var.db_type == "rds" ? aws_db_instance.rds_db[0].port : aws_rds_cluster.aurora_cluster[0].port
-    identifier      = var.db_type == "rds" ? aws_db_instance.rds_db[0].name : aws_rds_cluster.aurora_cluster[0].cluster_identifier
+    identifier      = var.db_type == "rds" ? aws_db_instance.rds_db[0].db_name : aws_rds_cluster.aurora_cluster[0].cluster_identifier
     engine          = var.db_type == "rds" ? aws_db_instance.rds_db[0].engine : aws_rds_cluster.aurora_cluster[0].engine
     reader_endpoint = var.db_type == "aurora" ? aws_rds_cluster.aurora_cluster[0].reader_endpoint : "null"
   }

--- a/ssm.tf
+++ b/ssm.tf
@@ -50,5 +50,5 @@ resource "aws_ssm_parameter" "rds_db_name" {
   name        = "/rds/${var.environment_name}-${var.name}/NAME"
   description = "RDS DB Name"
   type        = "String"
-  value       = var.db_type == "rds" ? aws_db_instance.rds_db[0].name : aws_rds_cluster.aurora_cluster[0].database_name
+  value       = var.db_type == "rds" ? aws_db_instance.rds_db[0].db_name : aws_rds_cluster.aurora_cluster[0].database_name
 }


### PR DESCRIPTION
Just a fix for a deprecated attribute warning. The `name` attribute is no longer supported on `aws_db_instance` and needs to be replaced with `db_name`. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#name

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
