### PR TITLE
Add ignore_changes for replicate_source_db and Configure Subnet Group with Public Access for RDS Replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | database\_name | Database Name | `string` | `""` | no |
 | db\_parameters | A list of DB parameters (map) to apply | `list(map(string))` | `[]` | no |
 | db\_subnet\_group\_id | RDS Subnet Group Name | `string` | n/a | yes |
+| db\_subnet\_group\_replica\_id | RDS Subnet Group Name | `string` | n/a | yes |
 | db\_subnet\_group\_subnet\_ids | List of Subnet IDs for the RDS Subnet Group | `list` | `[]` | no |
 | db\_type | Valid values are: rds, aurora or serverless | `string` | n/a | yes |
 | deletion\_protection | The database can't be deleted when this value is set to true. | `bool` | `false` | no |
@@ -73,6 +74,7 @@
 | preferred\_backup\_window | (Aurora Only) The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"07:00-09:00"` | no |
 | preferred\_maintenance\_window | (Aurora Only) The weekly time range during which system maintenance can occur, in (UTC) e.g., wed:04:00-wed:04:30 | `string` | `"Sun:04:00-Sun:05:00"` | no |
 | publicly\_accessible | (Optional) Bool to control if instance is publicly accessible | `bool` | `false` | no |
+| publicly\_accessible\_replica | (Optional) Bool to control if instance is publicly accessible | `bool` | `false` | no |
 | retention | Snapshot retention period in days | `number` | n/a | yes |
 | secret\_method | Use ssm for SSM parameters store which is the default option, or secretsmanager for AWS Secrets Manager | `string` | `"ssm"` | no |
 | skip\_final\_snapshot | Skips the final snapshot if the database is destroyed programatically | `bool` | `false` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -159,6 +159,11 @@ variable "db_subnet_group_id" {
   type        = string
 }
 
+variable "db_subnet_group_replica_id" {
+  description = "RDS Subnet Group Name"
+  type        = string
+}
+
 variable "db_subnet_group_subnet_ids" {
   description = "List of Subnet IDs for the RDS Subnet Group"
   default     = []
@@ -308,6 +313,12 @@ variable "option_name" {
 }
 
 variable "publicly_accessible" {
+  description = "(Optional) Bool to control if instance is publicly accessible"
+  type        = bool
+  default     = false
+}
+
+variable "publicly_accessible_replica" {
   description = "(Optional) Bool to control if instance is publicly accessible"
   type        = bool
   default     = false

--- a/rds.tf
+++ b/rds.tf
@@ -120,16 +120,14 @@ resource "aws_iam_role" "rds_monitoring" {
 resource "aws_db_instance" "rds_replica" {
   count                  = var.db_type == "rds" && var.enable_replica ? 1 : 0
   identifier             = var.identifier == "" ? "${var.environment_name}-${var.name}-replica" : "${var.identifier}-replica"
-  engine                 = var.engine
-  engine_version         = var.engine_version
   instance_class         = var.instance_class_replica == null ? var.instance_class : var.instance_class_replica
   allocated_storage      = var.allocated_storage
   storage_type           = var.storage_type
-  username               = var.user
-  password               = random_string.rds_db_password.result
   parameter_group_name   = var.create_db_parameter_group == true ? aws_db_parameter_group.rds_custom_db_pg[count.index].name : ""
   skip_final_snapshot    = var.skip_final_snapshot
-  replicate_source_db    = aws_db_instance.rds_db[0].id
+  replicate_source_db    = aws_db_instance.rds_db[0].arn
   vpc_security_group_ids = [aws_security_group.rds_db.id]
   storage_encrypted      = var.storage_encrypted
+  db_subnet_group_name   = try(var.db_subnet_group_replica_id, null)
+  publicly_accessible    = var.publicly_accessible_replica
 }

--- a/rds.tf
+++ b/rds.tf
@@ -129,5 +129,10 @@ resource "aws_db_instance" "rds_replica" {
   vpc_security_group_ids = [aws_security_group.rds_db.id]
   storage_encrypted      = var.storage_encrypted
   db_subnet_group_name   = try(var.db_subnet_group_replica_id, null)
-  publicly_accessible    = var.publicly_accessible_replica
+  publicly_accessible             = var.publicly_accessible_replica
+  lifecycle {
+    ignore_changes = [
+      replicate_source_db
+    ]
+  }
 }


### PR DESCRIPTION
This pull request includes two main updates:

Lifecycle Ignore for replicate_source_db:

Added a lifecycle block with ignore_changes for the replicate_source_db attribute in the aws_db_instance resource.
This change addresses a limitation where updates to the ARN require the resource name to be updated. By ignoring changes to replicate_source_db, we prevent unnecessary updates and maintain consistency with the current workaround.
Subnet Group and Public Access Configuration for RDS Replica:

Added a new subnet group configuration for the RDS replica to ensure it operates across different subnets.
Enabled the public access flag for the RDS replica to facilitate external connectivity if required.
Changes Made:
Ignore Changes: Applied ignore_changes to the replicate_source_db attribute to handle ARN update limitations.
Subnet Group: Configured a new subnet group for the RDS replica.
