### PR TITLE
Adding allow_cidrs for replica instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 |------|-------------|------|---------|:--------:|
 | allocated\_storage | Storage size in GB | `number` | `null` | no |
 | allow\_cidrs | List of CIDRs to allow connection to this DB | `list(string)` | `[]` | no |
+| allow\_cidrs\_replica | List of CIDRs to allow connection to this DB Replica | `list(string)` | `[]` | no |
 | allow\_security\_group\_ids | List of Security Group IDs to allow connection to this DB | <pre>list(object({<br>    security_group_id = string<br>    description       = string<br>    name              = string<br>  }))</pre> | `[]` | no |
+| allow\_security\_group\_ids\_replica | List of Security Group IDs to allow connection to this DB Replica | <pre>list(object({<br>    security_group_id = string<br>    description       = string<br>    name              = string<br>  }))</pre> | `[]` | no |
 | apply\_immediately | Apply changes immediately or wait for the maintainance window | `bool` | `true` | no |
 | auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
 | backup | Enables automatic backup with AWS Backup | `bool` | n/a | yes |

--- a/_variables.tf
+++ b/_variables.tf
@@ -28,10 +28,26 @@ variable "allow_security_group_ids" {
   default     = []
 }
 
+variable "allow_security_group_ids_replica" {
+  type = list(object({
+    security_group_id = string
+    description       = string
+    name              = string
+  }))
+  description = "List of Security Group IDs to allow connection to this DB Replica"
+  default     = []
+}
+
 variable "allow_cidrs" {
   type        = list(string)
   default     = []
   description = "List of CIDRs to allow connection to this DB"
+}
+
+variable "allow_cidrs_replica" {
+  type        = list(string)
+  default     = []
+  description = "List of CIDRs to allow connection to this DB Replica"
 }
 
 variable "user" {

--- a/rds.tf
+++ b/rds.tf
@@ -126,7 +126,7 @@ resource "aws_db_instance" "rds_replica" {
   parameter_group_name   = var.create_db_parameter_group == true ? aws_db_parameter_group.rds_custom_db_pg[count.index].name : ""
   skip_final_snapshot    = var.skip_final_snapshot
   replicate_source_db    = aws_db_instance.rds_db[0].arn
-  vpc_security_group_ids = [aws_security_group.rds_db.id]
+  vpc_security_group_ids = [aws_security_group.rds_db_replica.id]
   storage_encrypted      = var.storage_encrypted
   db_subnet_group_name   = try(var.db_subnet_group_replica_id, null)
   publicly_accessible             = var.publicly_accessible_replica

--- a/sg.tf
+++ b/sg.tf
@@ -8,6 +8,15 @@ resource "aws_security_group" "rds_db" {
   }
 }
 
+resource "aws_security_group" "rds_db_replica" {
+  name   = "rds-${var.environment_name}-${var.name}-replica"
+  vpc_id = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_security_group_rule" "rds_db_inbound_cidrs" {
   count             = length(var.allow_cidrs) != 0 ? 1 : 0
   type              = "ingress"
@@ -16,7 +25,7 @@ resource "aws_security_group_rule" "rds_db_inbound_cidrs" {
   protocol          = "tcp"
   cidr_blocks       = var.allow_cidrs
   security_group_id = aws_security_group.rds_db.id
-  description       = "From CIDR ${join(", ", slice(var.allow_cidrs, 0, 10))}"
+  description       = "From CIDR ${join(", ", var.allow_cidrs)}"
 }
 
 resource "aws_security_group_rule" "rds_db_inbound_from_sg" {
@@ -36,5 +45,38 @@ resource "aws_security_group_rule" "egress_rule" {
   to_port           = 0
   protocol          = "-1"
   security_group_id = aws_security_group.rds_db.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+##SG for Replica
+
+resource "aws_security_group_rule" "rds_db_inbound_cidrs_replica" {
+  count             = length(var.allow_cidrs_replica) != 0 ? 1 : 0
+  type              = "ingress"
+  from_port         = var.port
+  to_port           = var.port
+  protocol          = "tcp"
+  cidr_blocks       = var.allow_cidrs_replica
+  security_group_id = aws_security_group.rds_db_replica.id
+  description       = "From CIDR ${join(", ", var.allow_cidrs_replica)}"
+}
+
+resource "aws_security_group_rule" "rds_db_inbound_from_sg_replica" {
+  for_each                 = { for security_group_id in var.allow_security_group_ids_replica : security_group_id.name => security_group_id }
+  type                     = "ingress"
+  from_port                = var.port
+  to_port                  = var.port
+  protocol                 = "tcp"
+  source_security_group_id = each.value.security_group_id
+  security_group_id        = aws_security_group.rds_db_replica.id
+  description              = try(each.value.description, "From ${each.value.security_group_id}")
+}
+
+resource "aws_security_group_rule" "egress_rule_replica" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.rds_db_replica.id
   cidr_blocks       = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
Description:
This PR introduces the allow_cidrs variable to the Terraform module, enabling the configuration of CIDR blocks specifically for the replica instance. Previously, the module allowed setting CIDRs for the primary instance, but this enhancement extends that capability to the replica as well.

Changes:
Added allow_cidrs variable for the replica instance configuration.
Updated relevant Terraform files to include and manage the new variable.
Why:
Allowing CIDR blocks for the replica instance improves network security and flexibility, ensuring that both primary and replica instances can be securely accessed according to specified CIDR blocks.

