### PR TITLE
use existing option group

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 | storage\_encrypted | Enables storage encryption | `bool` | `true` | no |
 | storage\_type | The instance storage type | `string` | `"gp2"` | no |
 | tags | A map of tags to assign to the RDS | `map(string)` | `{}` | no |
+| use\_existing\_option\_group | (Optional) Use existing database option group | `bool` | `false` | no |
 | user | DB User | `string` | n/a | yes |
 | vpc\_id | n/a | `string` | n/a | yes |
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -253,6 +253,12 @@ variable "create_db_option_group" {
   default     = false
 }
 
+variable "use_existing_option_group" {
+  description = "(Optional) Use existing database option group"
+  type        = bool
+  default     = false
+}
+
 variable "option_group_name" {
   description = "Name of the option group"
   type        = string

--- a/rds.tf
+++ b/rds.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "rds_db" {
   multi_az                            = var.multi_az
   storage_encrypted                   = var.storage_encrypted
   parameter_group_name                = var.create_db_parameter_group == true ? aws_db_parameter_group.rds_custom_db_pg[count.index].name : ""
-  option_group_name                   = var.create_db_option_group == true ? aws_db_option_group.rds_custom_db_og[count.index].name : ""
+  option_group_name                   = var.create_db_option_group == true ? aws_db_option_group.rds_custom_db_og[count.index].name : (var.use_existing_option_group ? var.option_group_name : "")
   deletion_protection                 = var.deletion_protection
   performance_insights_enabled        = var.performance_insights_enabled
   enabled_cloudwatch_logs_exports     = var.enabled_cloudwatch_logs_exports


### PR DESCRIPTION
This feature enables the creation of an RDS instance using an existing option group, eliminating the need for a new one.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Edge Points:

If an option group needs to be changed after the RDS instance is created, it may cause the error: "The option group 'option-group-name' cannot be deleted because it is in use."
In this case, it may be necessary to change the retention variable value from X to 0 to disassociate the option group from any existing snapshot. Afterwards, the retention value will need to be reverted back to X.